### PR TITLE
Merge tag 'android-11.0.0_r20' of https://android.googlesource.com/platform/system/bt into 11

### DIFF
--- a/apex/Android.bp
+++ b/apex/Android.bp
@@ -4,10 +4,10 @@ apex {
     manifest: "apex_manifest.json",
 
     native_shared_libs: [
-      "libbluetooth_jni",
+      "//packages/apps/Bluetooth:libbluetooth_jni",
       "libbluetooth"
     ],
-    apps: ["Bluetooth"],
+    apps: ["//packages/apps/Bluetooth:Bluetooth"],
 
     compile_multilib: "both",
 

--- a/device/include/interop_database.h
+++ b/device/include/interop_database.h
@@ -151,11 +151,17 @@ static const interop_addr_entry_t interop_addr_database[] = {
     // because BR/EDR address and ADV random address are the same
     {{{0xd4, 0x7a, 0xe2, 0, 0, 0}}, 3, INTEROP_DISABLE_NAME_REQUEST},
 
+    // Mazda Carkit
+    {{{0xfc, 0x35, 0xe6, 0, 0, 0}}, 3, INTEROP_AVRCP_1_4_ONLY},
+
     // Toyota Car Audio
     {{{0x00, 0x17, 0x53, 0, 0, 0}}, 3, INTEROP_AVRCP_1_4_ONLY},
 
     // Honda High End Carkit
     {{{0x9c, 0x8d, 0x7c, 0, 0, 0}}, 3, INTEROP_AVRCP_1_4_ONLY},
+
+    // Honda Civic Carkit
+    {{{0x0c, 0xd9, 0xc1, 0, 0, 0}}, 3, INTEROP_AVRCP_1_4_ONLY},
 };
 
 typedef struct {

--- a/packet/tests/avrcp/avrcp_test_packets.h
+++ b/packet/tests/avrcp/avrcp_test_packets.h
@@ -316,6 +316,10 @@ std::vector<uint8_t> set_addressed_player_response = {
 std::vector<uint8_t> set_browsed_player_request = {0x70, 0x00, 0x02, 0x00,
                                                    0x02};
 
+// AVRCP Set Browsed Player Request with player_id = 0
+std::vector<uint8_t> set_browsed_player_id_0_request = {0x70, 0x00, 0x02, 0x00,
+                                                        0x00};
+
 // AVRCP Set Browsed Player Response with num items = 4 and depth = 0
 std::vector<uint8_t> set_browsed_player_response = {
     0x70, 0x00, 0x0a, 0x04, 0x00, 0x00, 0x00,

--- a/profile/avrcp/device.cc
+++ b/profile/avrcp/device.cc
@@ -1257,6 +1257,14 @@ void Device::SetBrowsedPlayerResponse(
     return;
   }
 
+  if (pkt->GetPlayerId() == 0 && num_items == 0) {
+    // Response fail if no browsable player in Bluetooth Player
+    auto response = SetBrowsedPlayerResponseBuilder::MakeBuilder(
+        Status::PLAYER_NOT_BROWSABLE, 0x0000, num_items, 0, "");
+    send_message(label, true, std::move(response));
+    return;
+  }
+
   curr_browsed_player_id_ = pkt->GetPlayerId();
 
   // Clear the path and push the new root.

--- a/stack/avrc/avrc_pars_tg.cc
+++ b/stack/avrc/avrc_pars_tg.cc
@@ -71,6 +71,8 @@ static tAVRC_STS avrc_ctrl_pars_vendor_cmd(tAVRC_MSG_VENDOR* p_msg,
       break;
     }
     case AVRC_PDU_REGISTER_NOTIFICATION: /* 0x31 */
+      if (len < 5) return AVRC_STS_INTERNAL_ERR;
+
       BE_STREAM_TO_UINT8(p_result->reg_notif.event_id, p);
       BE_STREAM_TO_UINT32(p_result->reg_notif.param, p);
       break;

--- a/stack/btm/btm_sec.cc
+++ b/stack/btm/btm_sec.cc
@@ -4358,6 +4358,7 @@ void btm_sec_disconnected(uint16_t handle, uint8_t reason) {
               << p_dev_rec->bd_addr;
 
     bta_dm_remove_device(p_dev_rec->bd_addr);
+    return;
   }
 
   BTM_TRACE_EVENT("%s after update sec_flags=0x%x", __func__,

--- a/stack/sdp/sdp_server.cc
+++ b/stack/sdp/sdp_server.cc
@@ -118,9 +118,11 @@ void sdp_server_handle_client_req(tCONN_CB* p_ccb, BT_HDR* p_msg) {
 
   if (p_req + sizeof(pdu_id) + sizeof(trans_num) > p_req_end) {
     android_errorWriteLog(0x534e4554, "69384124");
+    android_errorWriteLog(0x534e4554, "169342531");
     trans_num = 0;
     sdpu_build_n_send_error(p_ccb, trans_num, SDP_INVALID_REQ_SYNTAX,
                             SDP_TEXT_BAD_HEADER);
+    return;
   }
 
   /* The first byte in the message is the pdu type */
@@ -131,8 +133,10 @@ void sdp_server_handle_client_req(tCONN_CB* p_ccb, BT_HDR* p_msg) {
 
   if (p_req + sizeof(param_len) > p_req_end) {
     android_errorWriteLog(0x534e4554, "69384124");
+    android_errorWriteLog(0x534e4554, "169342531");
     sdpu_build_n_send_error(p_ccb, trans_num, SDP_INVALID_REQ_SYNTAX,
                             SDP_TEXT_BAD_HEADER);
+    return;
   }
 
   BE_STREAM_TO_UINT16(param_len, p_req);

--- a/stack/smp/smp_act.cc
+++ b/stack/smp/smp_act.cc
@@ -1253,7 +1253,17 @@ void smp_key_distribution(tSMP_CB* p_cb, tSMP_INT_DATA* p_data) {
     /* state check to prevent re-entrant */
     if (smp_get_state() == SMP_STATE_BOND_PENDING) {
       if (p_cb->derive_lk) {
-        smp_derive_link_key_from_long_term_key(p_cb, NULL);
+        tBTM_SEC_DEV_REC* p_dev_rec = btm_find_dev(p_cb->pairing_bda);
+        if (!(p_dev_rec->sec_flags & BTM_SEC_LE_LINK_KEY_AUTHED) &&
+            (p_dev_rec->sec_flags & BTM_SEC_LINK_KEY_AUTHED)) {
+          SMP_TRACE_DEBUG(
+              "%s BR key is higher security than existing LE keys, don't "
+              "derive LK from LTK",
+              __func__);
+          android_errorWriteLog(0x534e4554, "158854097");
+        } else {
+          smp_derive_link_key_from_long_term_key(p_cb, NULL);
+        }
         p_cb->derive_lk = false;
       }
 

--- a/stack/smp/smp_br_main.cc
+++ b/stack/smp/smp_br_main.cc
@@ -303,7 +303,6 @@ void smp_br_state_machine_event(tSMP_CB* p_cb, tSMP_BR_EVENT event,
   tSMP_BR_STATE curr_state = p_cb->br_state;
   tSMP_BR_SM_TBL state_table;
   uint8_t action, entry;
-  tSMP_BR_ENTRY_TBL entry_table = smp_br_entry_table[p_cb->role];
 
   SMP_TRACE_EVENT("main %s", __func__);
   if (curr_state >= SMP_BR_STATE_MAX) {
@@ -316,6 +315,8 @@ void smp_br_state_machine_event(tSMP_CB* p_cb, tSMP_BR_EVENT event,
     android_errorWriteLog(0x534e4554, "80145946");
     return;
   }
+
+  tSMP_BR_ENTRY_TBL entry_table = smp_br_entry_table[p_cb->role];
 
   SMP_TRACE_DEBUG("SMP Role: %s State: [%s (%d)], Event: [%s (%d)]",
                   (p_cb->role == HCI_ROLE_SLAVE) ? "Slave" : "Master",


### PR DESCRIPTION
** Merge tag 'android-11.0.0_r20' of https://android.googlesource.com/platform/system/bt into 11

Android 11.0.0 Release 20 (RQ1A.201205.010)
* tag 'android-11.0.0_r20':
  Fix a security issue in sdp_server.cc
  Check Classic key before cross-key derivation
  Reject SetBrowsedPlayer if there is not browsable player
  HciHalRootCanalTest: Use ASSERT and retry reads
  fix oob in avrc_ctrl_pars_vendor_cmd
  Fix crash in smp_br_state_machine_event
  Add Mazda Carkit into IOP table to only use AVRCP 1.4
  Add Honda Civic Carkit into IOP table to only use AVRCP 1.4
  Don't persist bonds using sample LTK
  Send a response to an smp security request depending on the callback event
  Send a response to an smp security request depending on the callback event
  Send a response to an smp security request depending on the callback event
  Send a response to an smp security request depending on the callback event
  Send a response to an smp security request depending on the callback event
  Send a response to an smp security request depending on the callback event
  Return after removing sample LTK device
  Return after removing sample LTK device

Signed-off-by: OdSazib <odsazib@gmail.com>

** bluetooth: select bluetooth modules by fully qualified namespace.
    This corresponds to Android.bp changes in
    packages/apps/Bluetooth:86dd33026b2daedce89ddbf20760e22a1989734c.

Bug: 140404592
Change-Id: Icbf678be4bb89fb30c214b1ad0dda390140aa7ce